### PR TITLE
test warning ast only

### DIFF
--- a/test/dygraph_to_static/test_warning.py
+++ b/test/dygraph_to_static/test_warning.py
@@ -15,6 +15,8 @@
 import unittest
 import warnings
 
+from dygraph_to_static_util import ast_only_test, dy2static_unittest
+
 import paddle
 from paddle.static.nn import cond
 
@@ -37,12 +39,14 @@ def false_fn():
     return [paddle.to_tensor(3), [None, paddle.to_tensor(4)]]
 
 
+@dy2static_unittest
 class TestReturnNoneInIfelse(unittest.TestCase):
+    @ast_only_test
     def test_dy2static_warning(self):
         paddle.disable_static()
         with warnings.catch_warnings(record=True) as w:
             warnings.simplefilter("always")
-            fun1()
+            paddle.jit.to_static(fun1)()
             flag = False
             for warn in w:
                 if (


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Others
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others
### Describe
<!-- Describe what this PR does -->
test warning ast only
这个单测会检测cond op中的warning时候正确被抛出，但是sot中并不会走cond op，所以没有检测到warning，需要修改成ast only